### PR TITLE
Add MIME type for CSV files

### DIFF
--- a/lighttpd/conf.d/mimetypes.conf
+++ b/lighttpd/conf.d/mimetypes.conf
@@ -48,6 +48,7 @@
    ".rst"          =>      "text/plain",
    ".dtd"          =>      "text/xml",
    ".xml"          =>      "text/xml",
+   ".csv"          =>      "text/csv; charset=utf-8",
    ".mpeg"         =>      "video/mpeg",
    ".mpg"          =>      "video/mpeg",
    ".mov"          =>      "video/quicktime",


### PR DESCRIPTION
Add MIME type for comma-separated value files and use the UTF-8 charset:
*  `text/csv; charset=utf-8`

At the moment, they appear as type:
*  `application/octet-stream`

...which is the default type for unknown files.

This should fix the CSV file created by archmap.
Currently, when you open it in a browser some of
the text is incorrectly formatted.

References:
* https://archwomen.org/media/archmap/archmap.csv
* https://www.iana.org/assignments/media-types/text/csv