### PR TITLE
Update MIME type for plain text files

### DIFF
--- a/lighttpd/conf.d/mimetypes.conf
+++ b/lighttpd/conf.d/mimetypes.conf
@@ -42,7 +42,7 @@
    ".log"          =>      "text/plain",
    ".conf"         =>      "text/plain",
    ".text"         =>      "text/plain",
-   ".txt"          =>      "text/plain",
+   ".txt"          =>      "text/plain; charset=utf-8",
    ".spec"         =>      "text/plain",
    ".md"           =>      "text/plain",
    ".rst"          =>      "text/plain",


### PR DESCRIPTION
Update the MIME type for plain text files to use the UTF-8 charset:
* `text/plain; charset=utf-8`

At the moment, no charset is specified:
* `text/plain`

This should fix the text file created by archmap.
Currently, when you open it in a browser some of
the text is incorrectly formatted.

References:

* https://archwomen.org/media/archmap/archmap-users.txt
* https://www.iana.org/assignments/media-types/media-types.xhtml#text